### PR TITLE
Implement focus manager and small refactor of focus trap

### DIFF
--- a/src/libs/focus/ElementTreeWalker.ts
+++ b/src/libs/focus/ElementTreeWalker.ts
@@ -1,0 +1,81 @@
+import { createDomWalker } from './utils'
+
+export class ElementTreeWalker {
+  private walker: TreeWalker
+
+  private currentElement: HTMLElement | null
+
+  constructor(root: HTMLElement, filter: (node: HTMLElement) => boolean) {
+    this.walker = createDomWalker(root, (node) => filter(node as HTMLElement))
+    this.currentElement = null
+  }
+
+  /**
+   * Get root element
+   */
+  get root() {
+    return this.walker.root as HTMLElement
+  }
+
+  /**
+   * Get current element
+   */
+  get current() {
+    return this.currentElement === this.root ? null : this.currentElement
+  }
+
+  /**
+   * Set current element
+   */
+  set current(node: HTMLElement | null) {
+    const current = this.root.contains(node) ? node : null
+
+    this.currentElement = current
+    this.walker.currentNode = current ?? this.root
+  }
+
+  /**
+   * Move to first element of root
+   */
+  first() {
+    this.walker.currentNode = this.walker.root
+
+    return this.next()
+  }
+
+  /**
+   * Move to last element of root
+   */
+  last() {
+    this.walker.currentNode = this.walker.root
+    let descendant: HTMLElement | null = null
+
+    while (this.walker.lastChild()) {
+      descendant = this.walker.currentNode as HTMLElement | null
+    }
+
+    this.currentElement = descendant
+
+    return descendant
+  }
+
+  /**
+   * Move to next element of root
+   */
+  next() {
+    this.currentElement = this.walker.nextNode() as HTMLElement | null
+
+    return this.currentElement
+  }
+
+  /**
+   * Move to previous element of root
+   */
+  previous() {
+    const previous = this.walker.previousNode() as HTMLElement | null
+
+    this.currentElement = previous === this.root ? null : previous
+
+    return this.currentElement
+  }
+}

--- a/src/libs/focus/FocusManagerScope.tsx
+++ b/src/libs/focus/FocusManagerScope.tsx
@@ -1,0 +1,29 @@
+import { createContext, FC, RefObject, useContext, useMemo } from 'react'
+
+import { createFocusManager, FocusManager } from './createFocusManager'
+
+const FocusManagerContext = createContext<FocusManager | null>(null)
+
+export interface FocusManagerScopeProps {
+  value: RefObject<HTMLElement>
+}
+
+export const FocusManagerScope: FC<FocusManagerScopeProps> = (props) => {
+  const { value, children } = props
+
+  const manager = useMemo(() => createFocusManager(value), [value])
+
+  return <FocusManagerContext.Provider value={manager}>{children}</FocusManagerContext.Provider>
+}
+
+export function useFocusManager() {
+  const manager = useContext(FocusManagerContext)
+
+  if (!manager) {
+    throw new Error(
+      'Could not find focus manager context value. Please ensure the component is wrapped in a <FocusManagerScope />',
+    )
+  }
+
+  return manager
+}

--- a/src/libs/focus/FocusNavigation.ts
+++ b/src/libs/focus/FocusNavigation.ts
@@ -1,0 +1,217 @@
+import { adjustedTabIndex } from './adjustedTabIndex'
+import { ElementTreeWalker } from './ElementTreeWalker'
+import { isFocusable } from './isFocusable'
+
+enum FocusDirection {
+  Backward,
+  Forward,
+}
+
+export interface FocusNavigationOptions {
+  tabbable?: boolean
+  wrap?: boolean
+  from?: HTMLElement | null
+}
+
+export class FocusNavigation {
+  private walker: ElementTreeWalker
+
+  constructor(scope: HTMLElement) {
+    this.walker = new ElementTreeWalker(scope, (el) => {
+      return scope !== el && scope.contains(el) && isFocusable(el)
+    })
+  }
+
+  private findElement(dir: FocusDirection, predicate: (element: HTMLElement) => boolean) {
+    const isForward = dir === FocusDirection.Forward
+
+    for (; this.walker.current; isForward ? this.walker.next() : this.walker.previous()) {
+      if (predicate(this.walker.current)) {
+        return this.walker.current
+      }
+    }
+
+    return null
+  }
+
+  private findElementWithTabIndex(tabIndex: number, dir: FocusDirection) {
+    return this.findElement(dir, (el) => adjustedTabIndex(el) === tabIndex)
+  }
+
+  private findFirstElementWithGreaterTabIndex(dir: FocusDirection) {
+    return this.findElement(dir, (el) => adjustedTabIndex(el) >= 0)
+  }
+
+  private findElementWithGreaterTabIndex(tabIndex: number) {
+    let candidateTabIndex = Number.MAX_SAFE_INTEGER
+    let candidate: HTMLElement | null = null
+
+    for (; this.walker.current; this.walker.next()) {
+      const currentTabIndex = adjustedTabIndex(this.walker.current)
+
+      if (currentTabIndex > tabIndex && (!candidate || currentTabIndex < candidateTabIndex)) {
+        candidate = this.walker.current
+        candidateTabIndex = currentTabIndex
+      }
+
+      // NOTE: the smallest tabIndex was found, but it is larger than the input tabIndex
+      if (candidateTabIndex === tabIndex + 1) {
+        break
+      }
+    }
+
+    this.walker.current = candidate
+
+    return candidate
+  }
+
+  private findElementWithLowerTabIndex(tabIndex: number) {
+    let candidateTabIndex = 0
+    let candidate: HTMLElement | null = null
+
+    for (; this.walker.current; this.walker.previous()) {
+      const currentTabIndex = adjustedTabIndex(this.walker.current)
+
+      if (currentTabIndex < tabIndex && currentTabIndex > candidateTabIndex) {
+        candidate = this.walker.current
+        candidateTabIndex = currentTabIndex
+      }
+
+      // NOTE: the largest tabIndex was found, but it is smaller than the input tabIndex
+      if (candidateTabIndex === tabIndex - 1) {
+        break
+      }
+    }
+
+    this.walker.current = candidate
+
+    return candidate
+  }
+
+  private findNextFocusable(tabbable?: boolean) {
+    const current = this.walker.current
+    const tabIndex = current ? adjustedTabIndex(current) : 0
+
+    if (current) {
+      if (!tabbable) {
+        return this.walker.next()
+      }
+
+      if (tabIndex >= 0) {
+        this.walker.next()
+        const candidate = this.findElementWithTabIndex(tabIndex, FocusDirection.Forward)
+
+        if (candidate) {
+          return candidate
+        }
+      } else {
+        const candidate = this.findFirstElementWithGreaterTabIndex(FocusDirection.Forward)
+
+        if (candidate) {
+          return candidate
+        }
+      }
+
+      if (tabIndex === 0) {
+        return null
+      }
+    }
+
+    this.walker.first()
+
+    if (!tabbable) {
+      return this.walker.current
+    }
+
+    const candidate = this.findElementWithGreaterTabIndex(tabIndex)
+    if (candidate) {
+      return candidate
+    }
+
+    this.walker.first()
+
+    return this.findElementWithTabIndex(0, FocusDirection.Forward)
+  }
+
+  private findPreviousFocusable(tabbable?: boolean) {
+    const current = this.walker.current
+
+    if (!current) {
+      this.walker.last()
+    } else {
+      this.walker.previous()
+    }
+
+    if (!tabbable) {
+      return this.walker.current
+    }
+
+    const tabIndex = current ? adjustedTabIndex(current) : 0
+
+    if (tabIndex < 0) {
+      const candidate = this.findFirstElementWithGreaterTabIndex(FocusDirection.Backward)
+
+      if (candidate) {
+        return candidate
+      }
+    } else {
+      const candidate = this.findElementWithTabIndex(tabIndex, FocusDirection.Backward)
+
+      if (candidate) {
+        return candidate
+      }
+    }
+
+    this.walker.last()
+
+    return this.findElementWithLowerTabIndex(tabIndex > 0 ? tabIndex : Number.MAX_SAFE_INTEGER)
+  }
+
+  get scope() {
+    return this.walker.root
+  }
+
+  get current() {
+    return this.walker.current
+  }
+
+  next(options: FocusNavigationOptions = {}) {
+    const { tabbable, from, wrap } = options
+
+    if (from !== undefined) {
+      this.walker.current = from
+    }
+
+    const node = this.findNextFocusable(tabbable)
+
+    if (!node && wrap) {
+      return this.findNextFocusable(tabbable)
+    }
+
+    return node
+  }
+
+  previous(options: FocusNavigationOptions = {}) {
+    const { tabbable, from, wrap } = options
+
+    if (from !== undefined) {
+      this.walker.current = from
+    }
+
+    const node = this.findPreviousFocusable(tabbable)
+
+    if (!node && wrap) {
+      return this.findPreviousFocusable(tabbable)
+    }
+
+    return node
+  }
+
+  first(tabbable?: boolean) {
+    return this.next({ from: null, tabbable })
+  }
+
+  last(tabbable?: boolean) {
+    return this.previous({ from: null, tabbable })
+  }
+}

--- a/src/libs/focus/__tests__/ElementTreeWalker.test.tsx
+++ b/src/libs/focus/__tests__/ElementTreeWalker.test.tsx
@@ -1,0 +1,58 @@
+import { createClientRender, screen } from '../../testing'
+import { ElementTreeWalker } from '../ElementTreeWalker'
+
+describe('ElementTreeWalker', () => {
+  const render = createClientRender()
+
+  test('should returns null if previous node is root', () => {
+    render(
+      <div data-testid="root">
+        <div />
+        <div />
+      </div>,
+    )
+
+    const walker = new ElementTreeWalker(
+      screen.getByTestId('root'),
+      (node) => node.tagName === 'DIV',
+    )
+
+    walker.next()
+    expect(walker.previous()).toBe(null)
+  })
+
+  test('should returns null of current after set root node', () => {
+    render(
+      <div data-testid="root">
+        <div />
+        <div />
+      </div>,
+    )
+
+    const walker = new ElementTreeWalker(
+      screen.getByTestId('root'),
+      (node) => node.tagName === 'DIV',
+    )
+
+    walker.current = walker.root
+    expect(walker.current).toBe(null)
+  })
+
+  test('should returns last element', () => {
+    render(
+      <div data-testid="root">
+        <div>
+          <div />
+          <div data-testid="last" />
+        </div>
+      </div>,
+    )
+
+    const walker = new ElementTreeWalker(
+      screen.getByTestId('root'),
+      (node) => node.tagName === 'DIV',
+    )
+
+    expect(walker.last()).toBe(screen.getByTestId('last'))
+  })
+})

--- a/src/libs/focus/__tests__/FocusManagerScope.test.tsx
+++ b/src/libs/focus/__tests__/FocusManagerScope.test.tsx
@@ -1,0 +1,284 @@
+import { createRef, forwardRef, PropsWithChildren, useImperativeHandle, useRef } from 'react'
+
+import { createClientRender, renderHook, screen } from '../../testing'
+import { FocusManager } from '../createFocusManager'
+import { useFocusManager, FocusManagerScope } from '../FocusManagerScope'
+
+const UseFocusManager = forwardRef<FocusManager, {}>((_props, ref) => {
+  const manager = useFocusManager()
+
+  useImperativeHandle(ref, () => manager, [manager])
+
+  return null
+})
+
+const Fixture = forwardRef<FocusManager, PropsWithChildren<{}>>(({ children }, ref) => {
+  const scopeRef = useRef<HTMLDivElement>(null)
+
+  return (
+    <FocusManagerScope value={scopeRef}>
+      <UseFocusManager ref={ref} />
+      <div ref={scopeRef} data-testid="scope">
+        {children}
+      </div>
+    </FocusManagerScope>
+  )
+})
+
+describe('FocusManagerScope', () => {
+  const render = createClientRender()
+
+  test('should throw an error if there is no <FocusManagerScope />', () => {
+    const { result } = renderHook(() => useFocusManager())
+
+    expect(result.error).toBeInstanceOf(Error)
+    expect(result.error?.message).toMatch(/Could not find focus manager context value/)
+  })
+
+  test('should provide a safe method call of focus manager', () => {
+    const scopeRef = createRef<HTMLElement>()
+    const { result } = renderHook(() => useFocusManager(), {
+      initialProps: { scopeRef },
+      wrapper: ({ children }) => <FocusManagerScope value={scopeRef}>{children}</FocusManagerScope>,
+    })
+
+    expect(result.current.focusFirst()).toBe(null)
+    expect(result.current.focusLast()).toBe(null)
+    expect(result.current.focusNext()).toBe(null)
+    expect(result.current.focusPrevious()).toBe(null)
+  })
+
+  test('should move focus to first tabbable element', () => {
+    const ref = createRef<FocusManager>()
+
+    render(
+      <Fixture ref={ref}>
+        <input />
+        <input tabIndex={1} data-testid="item" />
+        <input />
+      </Fixture>,
+    )
+
+    ref.current?.focusNext({ from: null, tabbable: true })
+
+    expect(screen.getByTestId('item')).toHaveFocus()
+  })
+
+  test('should move focus to first focusable element', () => {
+    const ref = createRef<FocusManager>()
+
+    render(
+      <Fixture ref={ref}>
+        <input data-testid="item" />
+        <input tabIndex={1} />
+        <input />
+      </Fixture>,
+    )
+
+    ref.current?.focusNext({ from: null })
+
+    expect(screen.getByTestId('item')).toHaveFocus()
+  })
+
+  test('should move focus to last tabbable element', () => {
+    const ref = createRef<FocusManager>()
+
+    render(
+      <Fixture ref={ref}>
+        <input />
+        <input tabIndex={1} />
+        <input data-testid="item" />
+      </Fixture>,
+    )
+
+    ref.current?.focusPrevious({ from: null, tabbable: true })
+
+    expect(screen.getByTestId('item')).toHaveFocus()
+  })
+
+  test('should move focus to last focusable element', () => {
+    const ref = createRef<FocusManager>()
+
+    render(
+      <Fixture ref={ref}>
+        <input />
+        <input tabIndex={1} />
+        <input data-testid="item" />
+      </Fixture>,
+    )
+
+    ref.current?.focusPrevious({ from: null })
+
+    expect(screen.getByTestId('item')).toHaveFocus()
+  })
+
+  test('should move focus to next focusable element', () => {
+    const ref = createRef<FocusManager>()
+
+    render(
+      <Fixture ref={ref}>
+        <input tabIndex={-1} data-testid="item-1" />
+        <input tabIndex={0} data-testid="item-2" />
+        <input tabIndex={1} data-testid="item-3" />
+      </Fixture>,
+    )
+
+    ref.current?.focusNext()
+    expect(screen.getByTestId('item-1')).toHaveFocus()
+
+    ref.current?.focusNext()
+    expect(screen.getByTestId('item-2')).toHaveFocus()
+
+    ref.current?.focusNext()
+    expect(screen.getByTestId('item-3')).toHaveFocus()
+
+    const focused = ref.current?.focusNext()
+    expect(focused).toBe(null)
+    expect(screen.getByTestId('item-3')).toHaveFocus()
+  })
+
+  test('should move focus to next tabbable element', () => {
+    const ref = createRef<FocusManager>()
+
+    render(
+      <Fixture ref={ref}>
+        <input tabIndex={-1} data-testid="item-1" />
+        <input tabIndex={0} data-testid="item-2" />
+        <input tabIndex={1} data-testid="item-3" />
+      </Fixture>,
+    )
+
+    ref.current?.focusNext({ tabbable: true })
+    expect(screen.getByTestId('item-3')).toHaveFocus()
+
+    ref.current?.focusNext({ tabbable: true })
+    expect(screen.getByTestId('item-2')).toHaveFocus()
+
+    const focused = ref.current?.focusNext({ tabbable: true })
+    expect(focused).toBe(null)
+    expect(screen.getByTestId('item-2')).toHaveFocus()
+  })
+
+  test('should move focus to previous focusable element', () => {
+    const ref = createRef<FocusManager>()
+
+    render(
+      <Fixture ref={ref}>
+        <input tabIndex={0} data-testid="item-1" />
+        <input tabIndex={1} data-testid="item-2" />
+        <input tabIndex={-1} data-testid="item-3" />
+      </Fixture>,
+    )
+
+    ref.current?.focusPrevious()
+    expect(screen.getByTestId('item-3')).toHaveFocus()
+
+    ref.current?.focusPrevious()
+    expect(screen.getByTestId('item-2')).toHaveFocus()
+
+    ref.current?.focusPrevious()
+    expect(screen.getByTestId('item-1')).toHaveFocus()
+
+    const focused = ref.current?.focusPrevious()
+    expect(focused).toBe(null)
+    expect(screen.getByTestId('item-1')).toHaveFocus()
+  })
+
+  test('should move focus to previous tabbable element', () => {
+    const ref = createRef<FocusManager>()
+
+    render(
+      <Fixture ref={ref}>
+        <input tabIndex={0} data-testid="item-1" />
+        <input tabIndex={1} data-testid="item-2" />
+        <input tabIndex={-1} data-testid="item-3" />
+      </Fixture>,
+    )
+
+    ref.current?.focusPrevious({ tabbable: true })
+    expect(screen.getByTestId('item-1')).toHaveFocus()
+
+    ref.current?.focusPrevious({ tabbable: true })
+    expect(screen.getByTestId('item-2')).toHaveFocus()
+
+    const focused = ref.current?.focusPrevious({ tabbable: true })
+    expect(focused).toBe(null)
+    expect(screen.getByTestId('item-2')).toHaveFocus()
+  })
+
+  test('should move focus forward and wrap around', () => {
+    const ref = createRef<FocusManager>()
+
+    render(
+      <Fixture ref={ref}>
+        <input data-testid="item-1" />
+        <input data-testid="item-2" />
+      </Fixture>,
+    )
+
+    ref.current?.focusNext({ tabbable: true, wrap: true })
+    expect(screen.getByTestId('item-1')).toHaveFocus()
+
+    ref.current?.focusNext({ tabbable: true, wrap: true })
+    expect(screen.getByTestId('item-2')).toHaveFocus()
+
+    ref.current?.focusNext({ tabbable: true, wrap: true })
+    expect(screen.getByTestId('item-1')).toHaveFocus()
+  })
+
+  test('should move focus backward and wrap around', () => {
+    const ref = createRef<FocusManager>()
+
+    render(
+      <Fixture ref={ref}>
+        <input data-testid="item-1" />
+        <input data-testid="item-2" />
+      </Fixture>,
+    )
+
+    ref.current?.focusPrevious({ tabbable: true, wrap: true })
+    expect(screen.getByTestId('item-2')).toHaveFocus()
+
+    ref.current?.focusPrevious({ tabbable: true, wrap: true })
+    expect(screen.getByTestId('item-1')).toHaveFocus()
+
+    ref.current?.focusPrevious({ tabbable: true, wrap: true })
+    expect(screen.getByTestId('item-2')).toHaveFocus()
+  })
+
+  test('should move focus to first element', () => {
+    const ref = createRef<FocusManager>()
+
+    render(
+      <Fixture ref={ref}>
+        <input tabIndex={-1} data-testid="item-1" />
+        <input data-testid="item-2" />
+        <input data-testid="item-3" />
+      </Fixture>,
+    )
+
+    ref.current?.focusFirst()
+    expect(screen.getByTestId('item-1')).toHaveFocus()
+
+    ref.current?.focusFirst({ tabbable: true })
+    expect(screen.getByTestId('item-2')).toHaveFocus()
+  })
+
+  test('should move focus to last element', () => {
+    const ref = createRef<FocusManager>()
+
+    render(
+      <Fixture ref={ref}>
+        <input data-testid="item-1" />
+        <input data-testid="item-2" />
+        <input tabIndex={-1} data-testid="item-3" />
+      </Fixture>,
+    )
+
+    ref.current?.focusLast()
+    expect(screen.getByTestId('item-3')).toHaveFocus()
+
+    ref.current?.focusLast({ tabbable: true })
+    expect(screen.getByTestId('item-2')).toHaveFocus()
+  })
+})

--- a/src/libs/focus/__tests__/FocusNavigation.test.tsx
+++ b/src/libs/focus/__tests__/FocusNavigation.test.tsx
@@ -1,0 +1,512 @@
+import { createClientRender, screen } from '../../testing'
+import { FocusNavigation } from '../FocusNavigation'
+
+describe('FocusNavigation', () => {
+  const render = createClientRender()
+
+  test('should returns correct scope element', () => {
+    const scope = document.createElement('div')
+    const navigation = new FocusNavigation(scope)
+
+    expect(navigation.scope).toBe(scope)
+  })
+
+  test('should returns null of current after initialize', () => {
+    const scope = document.createElement('div')
+    const navigation = new FocusNavigation(scope)
+
+    expect(navigation.current).toBe(null)
+  })
+
+  test('should returns next tabbable from element with tabIndex = -1', () => {
+    render(
+      <div data-testid="scope">
+        <input tabIndex={0} data-testid="tabbable-1" />
+        <input tabIndex={-1} data-testid="focusable-1" />
+        <input tabIndex={1} data-testid="tabbable-2" />
+        <input tabIndex={-1} data-testid="focusable-2" />
+      </div>,
+    )
+
+    const scope = screen.getByTestId('scope')
+    const navigation = new FocusNavigation(scope)
+
+    const focused1 = navigation.next({ tabbable: true, from: screen.getByTestId('focusable-1') })
+    expect(focused1).toBe(screen.getByTestId('tabbable-2'))
+
+    const focused2 = navigation.next({ tabbable: true, from: screen.getByTestId('focusable-2') })
+    expect(focused2).toBe(screen.getByTestId('tabbable-1'))
+  })
+
+  test('should returns next tabbable element with greater tabIndex 0', () => {
+    render(
+      <div data-testid="scope">
+        <input tabIndex={0} data-testid="tabbable-1" />
+        <input tabIndex={1} data-testid="tabbable-2" />
+        <input tabIndex={1} data-testid="tabbable-3" />
+        <input tabIndex={2} data-testid="tabbable-4" />
+      </div>,
+    )
+
+    const scope = screen.getByTestId('scope')
+    const navigation = new FocusNavigation(scope)
+
+    const focused = navigation.next({ tabbable: true })
+
+    expect(focused).toBe(screen.getByTestId('tabbable-2'))
+  })
+
+  test('should returns next tabbable element with same tabIndex', () => {
+    render(
+      <div data-testid="scope">
+        <input tabIndex={0} data-testid="tabbable-1" />
+        <input tabIndex={1} data-testid="tabbable-2" />
+        <input tabIndex={2} data-testid="tabbable-3" />
+        <input tabIndex={1} data-testid="tabbable-4" />
+      </div>,
+    )
+
+    const scope = screen.getByTestId('scope')
+    const navigation = new FocusNavigation(scope)
+    const from = screen.getByTestId('tabbable-2')
+    const focused = navigation.next({ tabbable: true, from })
+
+    expect(focused).toBe(screen.getByTestId('tabbable-4'))
+  })
+
+  test('should returns null of next from last element with tabIndex = 0', () => {
+    render(
+      <div data-testid="scope">
+        <input tabIndex={0} data-testid="tabbable-1" />
+        <input tabIndex={1} data-testid="tabbable-2" />
+        <input tabIndex={2} data-testid="tabbable-3" />
+      </div>,
+    )
+
+    const scope = screen.getByTestId('scope')
+    const navigation = new FocusNavigation(scope)
+    const from = screen.getByTestId('tabbable-1')
+    const focused = navigation.next({ tabbable: true, from })
+
+    expect(focused).toBe(null)
+  })
+
+  test('should returns null of next from last tabbable element', () => {
+    render(
+      <div data-testid="scope">
+        <input tabIndex={1} data-testid="tabbable-1" />
+        <input tabIndex={2} data-testid="tabbable-2" />
+        <input tabIndex={3} data-testid="tabbable-3" />
+      </div>,
+    )
+
+    const scope = screen.getByTestId('scope')
+    const navigation = new FocusNavigation(scope)
+    const from = screen.getByTestId('tabbable-3')
+    const focused = navigation.next({ tabbable: true, from })
+
+    expect(focused).toBe(null)
+  })
+
+  test('should returns next element with tabIndex 0 from element with max tabIndex', () => {
+    render(
+      <div data-testid="scope">
+        <input tabIndex={1} data-testid="tabbable-1" />
+        <input tabIndex={0} data-testid="tabbable-2" />
+        <input tabIndex={2} data-testid="tabbable-3" />
+      </div>,
+    )
+
+    const scope = screen.getByTestId('scope')
+    const navigation = new FocusNavigation(scope)
+    const from = screen.getByTestId('tabbable-3')
+    const focused = navigation.next({ tabbable: true, from })
+
+    expect(focused).toBe(screen.getByTestId('tabbable-2'))
+  })
+
+  test('should returns next focusable element of normal dom order', () => {
+    render(
+      <div data-testid="scope">
+        <input tabIndex={-1} data-testid="focusable-1" />
+        <input tabIndex={0} data-testid="tabbable-1" />
+        <input tabIndex={1} data-testid="tabbable-2" />
+        <input tabIndex={-1} data-testid="focusable-2" />
+      </div>,
+    )
+
+    const scope = screen.getByTestId('scope')
+    const navigation = new FocusNavigation(scope)
+
+    const focused1 = navigation.next()
+    expect(focused1).toBe(screen.getByTestId('focusable-1'))
+
+    const focused2 = navigation.next({ from: screen.getByTestId('tabbable-2') })
+    expect(focused2).toBe(screen.getByTestId('focusable-2'))
+  })
+
+  test('should returns previous tabbable from element with tabIndex = -1', () => {
+    render(
+      <div data-testid="scope">
+        <input tabIndex={-1} data-testid="focusable-1" />
+        <input tabIndex={0} data-testid="tabbable-1" />
+        <input tabIndex={-1} data-testid="focusable-2" />
+        <input tabIndex={2} data-testid="tabbable-2" />
+      </div>,
+    )
+
+    const scope = screen.getByTestId('scope')
+    const navigation = new FocusNavigation(scope)
+
+    const focused1 = navigation.previous({
+      tabbable: true,
+      from: screen.getByTestId('focusable-1'),
+    })
+    expect(focused1).toBe(screen.getByTestId('tabbable-2'))
+
+    const focused2 = navigation.previous({
+      tabbable: true,
+      from: screen.getByTestId('focusable-2'),
+    })
+    expect(focused2).toBe(screen.getByTestId('tabbable-1'))
+  })
+
+  test('should returns previous tabbable element from end', () => {
+    render(
+      <div data-testid="scope">
+        <input tabIndex={1} data-testid="tabbable-1" />
+        <input tabIndex={0} data-testid="tabbable-2" />
+        <input tabIndex={2} data-testid="tabbable-3" />
+      </div>,
+    )
+
+    const scope = screen.getByTestId('scope')
+    const navigation = new FocusNavigation(scope)
+
+    const focused = navigation.previous({ tabbable: true })
+    expect(focused).toBe(screen.getByTestId('tabbable-2'))
+  })
+
+  test('should returns previous tabbable element with same tabIndex', () => {
+    render(
+      <div data-testid="scope">
+        <input tabIndex={1} data-testid="tabbable-1" />
+        <input tabIndex={0} data-testid="tabbable-2" />
+        <input tabIndex={1} data-testid="tabbable-3" />
+        <input tabIndex={2} data-testid="tabbable-4" />
+      </div>,
+    )
+
+    const scope = screen.getByTestId('scope')
+    const navigation = new FocusNavigation(scope)
+
+    const focused = navigation.previous({ tabbable: true, from: screen.getByTestId('tabbable-3') })
+    expect(focused).toBe(screen.getByTestId('tabbable-1'))
+  })
+
+  test('should returns previous tabbable element with lower tabIndex', () => {
+    render(
+      <div data-testid="scope">
+        <input tabIndex={0} data-testid="tabbable-1" />
+        <input tabIndex={1} data-testid="tabbable-2" />
+        <input tabIndex={2} data-testid="tabbable-3" />
+      </div>,
+    )
+
+    const scope = screen.getByTestId('scope')
+    const navigation = new FocusNavigation(scope)
+
+    const focused = navigation.previous({ tabbable: true, from: screen.getByTestId('tabbable-3') })
+    expect(focused).toBe(screen.getByTestId('tabbable-2'))
+  })
+
+  test('should returns previous focusable element of normal dom order', () => {
+    render(
+      <div data-testid="scope">
+        <input tabIndex={-1} data-testid="focusable-1" />
+        <input tabIndex={0} data-testid="tabbable-1" />
+        <input tabIndex={1} data-testid="tabbable-2" />
+        <input tabIndex={-1} data-testid="focusable-2" />
+      </div>,
+    )
+
+    const scope = screen.getByTestId('scope')
+    const navigation = new FocusNavigation(scope)
+
+    const focused1 = navigation.previous()
+    expect(focused1).toBe(screen.getByTestId('focusable-2'))
+
+    const focused2 = navigation.previous({ from: screen.getByTestId('tabbable-1') })
+    expect(focused2).toBe(screen.getByTestId('focusable-1'))
+  })
+
+  test('should returns first tabbable element from last with wrap option', () => {
+    render(
+      <div data-testid="scope">
+        <input tabIndex={1} data-testid="tabbable-1" />
+        <input tabIndex={0} data-testid="tabbable-2" />
+        <input tabIndex={2} data-testid="tabbable-3" />
+      </div>,
+    )
+
+    const scope = screen.getByTestId('scope')
+    const navigation = new FocusNavigation(scope)
+
+    const focused = navigation.next({
+      from: screen.getByTestId('tabbable-2'),
+      tabbable: true,
+      wrap: true,
+    })
+    expect(focused).toBe(screen.getByTestId('tabbable-1'))
+  })
+
+  test('should returns last tabbable element from first with wrap option', () => {
+    render(
+      <div data-testid="scope">
+        <input tabIndex={1} data-testid="tabbable-1" />
+        <input tabIndex={2} data-testid="tabbable-2" />
+        <input tabIndex={0} data-testid="tabbable-3" />
+      </div>,
+    )
+
+    const scope = screen.getByTestId('scope')
+    const navigation = new FocusNavigation(scope)
+
+    const focused = navigation.previous({
+      from: screen.getByTestId('tabbable-1'),
+      tabbable: true,
+      wrap: true,
+    })
+    expect(focused).toBe(screen.getByTestId('tabbable-3'))
+  })
+
+  test('should returns first focusable element from last with wrap option', () => {
+    render(
+      <div data-testid="scope">
+        <input tabIndex={-1} data-testid="focusable-1" />
+        <input tabIndex={0} data-testid="tabbable-2" />
+        <input tabIndex={-1} data-testid="focusable-3" />
+      </div>,
+    )
+
+    const scope = screen.getByTestId('scope')
+    const navigation = new FocusNavigation(scope)
+
+    const focused = navigation.next({
+      from: screen.getByTestId('focusable-3'),
+      wrap: true,
+    })
+    expect(focused).toBe(screen.getByTestId('focusable-1'))
+  })
+
+  test('should returns last focusable element from first with wrap option', () => {
+    render(
+      <div data-testid="scope">
+        <input tabIndex={-1} data-testid="focusable-1" />
+        <input tabIndex={0} data-testid="tabbable-2" />
+        <input tabIndex={-1} data-testid="focusable-3" />
+      </div>,
+    )
+
+    const scope = screen.getByTestId('scope')
+    const navigation = new FocusNavigation(scope)
+
+    const focused = navigation.previous({
+      from: screen.getByTestId('focusable-1'),
+      wrap: true,
+    })
+    expect(focused).toBe(screen.getByTestId('focusable-3'))
+  })
+
+  test('should returns first focusable element', () => {
+    render(
+      <div data-testid="scope">
+        <input tabIndex={-1} data-testid="focusable-1" />
+        <input tabIndex={0} data-testid="tabbable-2" />
+        <input tabIndex={-1} data-testid="focusable-3" />
+      </div>,
+    )
+
+    const scope = screen.getByTestId('scope')
+    const navigation = new FocusNavigation(scope)
+
+    const focused = navigation.first()
+    expect(focused).toBe(screen.getByTestId('focusable-1'))
+  })
+
+  test('should returns first tabbable element', () => {
+    render(
+      <div data-testid="scope">
+        <input tabIndex={-1} data-testid="focusable-1" />
+        <input tabIndex={0} data-testid="tabbable-2" />
+        <input tabIndex={0} data-testid="tabbable-3" />
+        <input tabIndex={-1} data-testid="focusable-4" />
+      </div>,
+    )
+
+    const scope = screen.getByTestId('scope')
+    const navigation = new FocusNavigation(scope)
+
+    const focused = navigation.first(true)
+    expect(focused).toBe(screen.getByTestId('tabbable-2'))
+  })
+
+  test('should returns last focusable element', () => {
+    render(
+      <div data-testid="scope">
+        <input tabIndex={-1} data-testid="focusable-1" />
+        <input tabIndex={0} data-testid="tabbable-2" />
+        <input tabIndex={-1} data-testid="focusable-3" />
+      </div>,
+    )
+
+    const scope = screen.getByTestId('scope')
+    const navigation = new FocusNavigation(scope)
+
+    const focused = navigation.last()
+    expect(focused).toBe(screen.getByTestId('focusable-3'))
+  })
+
+  test('should returns last tabbable element', () => {
+    render(
+      <div data-testid="scope">
+        <input tabIndex={-1} data-testid="focusable-1" />
+        <input tabIndex={0} data-testid="tabbable-2" />
+        <input tabIndex={0} data-testid="tabbable-3" />
+        <input tabIndex={-1} data-testid="focusable-4" />
+      </div>,
+    )
+
+    const scope = screen.getByTestId('scope')
+    const navigation = new FocusNavigation(scope)
+
+    const focused = navigation.last(true)
+    expect(focused).toBe(screen.getByTestId('tabbable-3'))
+  })
+
+  test('should returns first tabbable element from outside element of scope', () => {
+    render(
+      <>
+        <div data-testid="scope">
+          <input tabIndex={-1} data-testid="focusable-1" />
+          <input tabIndex={0} data-testid="tabbable-2" />
+          <input tabIndex={0} data-testid="tabbable-3" />
+          <input tabIndex={-1} data-testid="focusable-4" />
+        </div>
+        <div>
+          <input data-testid="outside" />
+        </div>
+      </>,
+    )
+
+    const scope = screen.getByTestId('scope')
+    const navigation = new FocusNavigation(scope)
+
+    const focused = navigation.next({ from: screen.getByTestId('outside'), tabbable: true })
+    expect(focused).toBe(screen.getByTestId('tabbable-2'))
+  })
+
+  test('should returns last tabbable element from outside element of scope', () => {
+    render(
+      <>
+        <div>
+          <input data-testid="outside" />
+        </div>
+        <div data-testid="scope">
+          <input tabIndex={-1} data-testid="focusable-1" />
+          <input tabIndex={0} data-testid="tabbable-2" />
+          <input tabIndex={0} data-testid="tabbable-3" />
+          <input tabIndex={-1} data-testid="focusable-4" />
+        </div>
+      </>,
+    )
+
+    const scope = screen.getByTestId('scope')
+    const navigation = new FocusNavigation(scope)
+
+    const focused = navigation.previous({ from: screen.getByTestId('outside'), tabbable: true })
+    expect(focused).toBe(screen.getByTestId('tabbable-3'))
+  })
+
+  test('complex returns all focusable and tabbable elements', () => {
+    render(
+      <div data-testid="scope">
+        <div contentEditable data-testid="content-editable-true" />
+        <div contentEditable={false} data-testid="content-editable-false" />
+        <span tabIndex={0} data-testid="span-tab-index-0" />
+        <span tabIndex={1} data-testid="span-tab-index-1" />
+        <a href="#" data-testid="a-with-href">
+          link
+        </a>
+        <audio controls data-testid="audio-with-controls" />
+        <video controls data-testid="video-with-controls" />
+        <button data-testid="button">button</button>
+        <button data-testid="button-disabled" disabled>
+          button
+        </button>
+        <select data-testid="select">
+          <option>option</option>
+        </select>
+        <textarea data-testid="textarea" defaultValue="text" />
+        <iframe data-testid="iframe" />
+        <form>
+          <input type="radio" name="radio-1" data-testid="radio-1" value="1" />
+          <input type="radio" name="radio-1" data-testid="radio-2" value="2" defaultChecked />
+          <input type="radio" name="radio-1" data-testid="radio-3" value="3" />
+        </form>
+      </div>,
+    )
+
+    // https://github.com/jsdom/jsdom/issues/1670
+    const divContentEditableTrue = screen.getByTestId('content-editable-true')
+    divContentEditableTrue.contentEditable = 'true'
+
+    const scope = screen.getByTestId('scope')
+    const navigation = new FocusNavigation(scope)
+
+    function collect(tabbable: boolean) {
+      const items: string[] = []
+      navigation.next({ tabbable, wrap: false, from: null })
+
+      for (; navigation.current; navigation.next({ tabbable, wrap: false })) {
+        const testId = navigation.current.dataset.testid
+        if (testId) {
+          items.push(testId)
+        }
+      }
+
+      return items
+    }
+
+    const focusables = collect(false)
+    expect(focusables).toEqual([
+      'content-editable-true',
+      'span-tab-index-0',
+      'span-tab-index-1',
+      'a-with-href',
+      'audio-with-controls',
+      'video-with-controls',
+      'button',
+      'select',
+      'textarea',
+      'iframe',
+      'radio-1',
+      'radio-2',
+      'radio-3',
+    ])
+
+    const tabbables = collect(true)
+    expect(tabbables).toEqual([
+      'span-tab-index-1',
+      'content-editable-true',
+      'span-tab-index-0',
+      'a-with-href',
+      'audio-with-controls',
+      'video-with-controls',
+      'button',
+      'select',
+      'textarea',
+      'radio-2',
+    ])
+  })
+})

--- a/src/libs/focus/adjustedTabIndex.ts
+++ b/src/libs/focus/adjustedTabIndex.ts
@@ -1,0 +1,58 @@
+import { ElementTreeWalker } from './ElementTreeWalker'
+import { isIframe, isRadioInput } from './utils'
+
+function getCheckedRadio(radio: HTMLInputElement) {
+  if (radio.checked) {
+    return radio
+  }
+
+  const walker = new ElementTreeWalker(radio.form || radio.ownerDocument.body, (element) => {
+    return (
+      isRadioInput(element) &&
+      element.name === radio.name &&
+      element.checked &&
+      element.form === radio.form
+    )
+  })
+
+  return walker.next()
+}
+
+function isTabbableRadio(radio: HTMLInputElement) {
+  if (!radio.name) {
+    return true
+  }
+
+  const checked = getCheckedRadio(radio)
+
+  return !checked || checked === radio
+}
+
+export function adjustedTabIndex(node: HTMLElement) {
+  if ((isRadioInput(node) && !isTabbableRadio(node)) || isIframe(node)) {
+    return -1
+  }
+
+  const tabIndex = parseInt(node.getAttribute('tabindex') || '', 10)
+
+  if (!isNaN(tabIndex)) {
+    return tabIndex
+  }
+
+  // Use fallback value for dom nodes with `contentEditable`,
+  // because browsers not returns correct `tabIndex` value.
+  if (node.contentEditable === 'true') {
+    return 0
+  }
+
+  // Use `tabIndex` fallback value for <details/>, <audio controls/> and <video controls/>,
+  // because Chrome returns "-1" and Firefox returns "0" when `tabIndex` not set.
+  if (
+    (node.nodeName === 'AUDIO' || node.nodeName === 'VIDEO' || node.nodeName === 'DETAILS') &&
+    node.getAttribute('tabindex') === null
+  ) {
+    return 0
+  }
+
+  return node.tabIndex
+}

--- a/src/libs/focus/createFocusManager.ts
+++ b/src/libs/focus/createFocusManager.ts
@@ -1,0 +1,77 @@
+import { RefObject } from 'react'
+
+import { focusElement } from '../dom-utils'
+import { FocusNavigation, FocusNavigationOptions } from './FocusNavigation'
+
+type FocusOptions = {
+  preventScroll?: boolean
+  tabbable?: boolean
+}
+
+type FocusManagerOptions = FocusOptions & FocusNavigationOptions
+
+export interface FocusManager {
+  focusFirst(options?: FocusOptions): HTMLElement | null
+  focusLast(options?: FocusOptions): HTMLElement | null
+  focusNext(options?: FocusManagerOptions): HTMLElement | null
+  focusPrevious(options?: FocusManagerOptions): HTMLElement | null
+}
+
+export function createFocusManager<T extends HTMLElement>(scopeRef: RefObject<T>): FocusManager {
+  let instance: FocusNavigation | null = null
+
+  function ensureNavigation<T>(callback: (instance: FocusNavigation) => T): T | null {
+    if (scopeRef.current && instance?.scope !== scopeRef.current) {
+      instance = new FocusNavigation(scopeRef.current)
+    }
+
+    if (instance) {
+      return callback(instance)
+    }
+
+    return null
+  }
+
+  function focusFirst(options: FocusOptions = {}) {
+    const { preventScroll, tabbable } = options
+    const element = ensureNavigation((navigation) => navigation.first(tabbable))
+
+    focusElement(element, preventScroll)
+
+    return element
+  }
+
+  function focusLast(options: FocusOptions = {}) {
+    const { preventScroll, tabbable } = options
+    const element = ensureNavigation((navigation) => navigation.last(tabbable))
+
+    focusElement(element, preventScroll)
+
+    return element
+  }
+
+  function focusNext(options: FocusManagerOptions = {}) {
+    const { preventScroll, ...opts } = options
+    const element = ensureNavigation((navigation) => navigation.next(opts))
+
+    focusElement(element, preventScroll)
+
+    return element
+  }
+
+  function focusPrevious(options: FocusManagerOptions = {}) {
+    const { preventScroll, ...opts } = options
+    const element = ensureNavigation((navigation) => navigation.previous(opts))
+
+    focusElement(element, preventScroll)
+
+    return element
+  }
+
+  return {
+    focusFirst,
+    focusLast,
+    focusNext,
+    focusPrevious,
+  }
+}

--- a/src/libs/focus/index.ts
+++ b/src/libs/focus/index.ts
@@ -1,0 +1,6 @@
+export * from './adjustedTabIndex'
+export * from './createFocusManager'
+export * from './ElementTreeWalker'
+export * from './FocusManagerScope'
+export * from './isFocusable'
+export * from './isTabbable'

--- a/src/libs/focus/isFocusable.ts
+++ b/src/libs/focus/isFocusable.ts
@@ -1,0 +1,30 @@
+import { isHidden, isHiddenInput, matches } from './utils'
+
+const FOCUSABLE_SELECTORS = [
+  '[contenteditable]:not([contenteditable="false"])',
+  '[tabindex]',
+  'a[href]',
+  'area[href]',
+  'audio[controls]',
+  'button',
+  'details',
+  'details>summary:first-of-type',
+  'input',
+  'select',
+  'textarea',
+  'video[controls]',
+  'iframe',
+].join(',')
+
+export function isFocusable(node: HTMLElement) {
+  if (
+    !matches(node, FOCUSABLE_SELECTORS) ||
+    isHiddenInput(node) ||
+    (node as any).disabled ||
+    isHidden(node)
+  ) {
+    return false
+  }
+
+  return true
+}

--- a/src/libs/focus/isTabbable.ts
+++ b/src/libs/focus/isTabbable.ts
@@ -1,0 +1,7 @@
+import { adjustedTabIndex } from './adjustedTabIndex'
+import { isFocusable } from './isFocusable'
+import { isIframe } from './utils'
+
+export function isTabbable(node: HTMLElement) {
+  return !isIframe(node) && isFocusable(node) && adjustedTabIndex(node) >= 0
+}

--- a/src/libs/focus/utils/createDomWalker.ts
+++ b/src/libs/focus/utils/createDomWalker.ts
@@ -8,7 +8,7 @@ export function createDomWalker(root: Node, predicate: (node: Node) => boolean) 
   }
 
   // IE11 require use function instead object.
-  const safeFilter = (acceptNode as unknown) as NodeFilter
+  const safeFilter = acceptNode as unknown as NodeFilter
   safeFilter.acceptNode = acceptNode
 
   const walker = document.createTreeWalker(

--- a/src/libs/focus/utils/dom-utils.ts
+++ b/src/libs/focus/utils/dom-utils.ts
@@ -1,0 +1,49 @@
+let protoMatches: Element['matches'] | null = null
+if (typeof Element !== 'undefined') {
+  protoMatches =
+    Element.prototype.matches ||
+    Element.prototype.webkitMatchesSelector ||
+    // @ts-expect-error
+    Element.prototype.matchesSelector ||
+    // @ts-expect-error
+    Element.prototype.mozMatchesSelector ||
+    // @ts-expect-error
+    Element.prototype.msMatchesSelector
+}
+
+export function matches(node: Element, selectors: string) {
+  return protoMatches ? protoMatches.call(node, selectors) : false
+}
+
+export function isInput(node: HTMLElement): node is HTMLInputElement {
+  return node.tagName === 'INPUT'
+}
+
+export function isIframe(node: HTMLElement): node is HTMLFrameElement {
+  return node.tagName === 'IFRAME'
+}
+
+export function isHiddenInput(node: HTMLElement): node is HTMLInputElement {
+  return isInput(node) && node.type === 'hidden'
+}
+
+export function isRadioInput(node: HTMLElement): node is HTMLInputElement {
+  return isInput(node) && node.type === 'radio'
+}
+
+export function isHidden(node: Element) {
+  if (window.getComputedStyle(node).visibility === 'hidden') {
+    return true
+  }
+
+  let parent: Element | null = node
+  while (parent) {
+    if (window.getComputedStyle(parent).display === 'none') {
+      return true
+    }
+
+    parent = parent.parentElement
+  }
+
+  return false
+}

--- a/src/libs/focus/utils/index.ts
+++ b/src/libs/focus/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './createDomWalker'
+export * from './dom-utils'


### PR DESCRIPTION
# Что сделано:

-  добавлена реализация менеджера фокуса, которая позволяет:
    - фокусировать следующий/предыдущий элемент внутри скоупа
    - фокусировать следующий/предыдущий элемент относительно какого-то элмента внутри скоупа
    - фокусировать первый/последний элемент внутри скоупа
    - поддерживает 2 способа фокусировки:
        - фокусировка согласно порядку в DOM
        - фокусировка согласно порядку `tabIndex`
 - небольшой рефакторинг `focus-trap`, где в целом код перенесен в другой модуль `focus` и разделен на более атомарные части