### PR TITLE
Impl useForwardedRef hook

### DIFF
--- a/src/libs/forward-ref/index.ts
+++ b/src/libs/forward-ref/index.ts
@@ -1,0 +1,1 @@
+export * from './useForwardedRef'

--- a/src/libs/forward-ref/readme.md
+++ b/src/libs/forward-ref/readme.md
@@ -1,0 +1,1 @@
+# forward-ref

--- a/src/libs/forward-ref/useForwardedRef.test.tsx
+++ b/src/libs/forward-ref/useForwardedRef.test.tsx
@@ -1,0 +1,30 @@
+import { MutableRefObject, createRef, forwardRef, useRef } from 'react'
+
+import { createClientRender, screen } from '../testing'
+import { useForwardedRef } from './useForwardedRef'
+
+const Fixture = forwardRef<HTMLDivElement>((_, forwardedRef) => {
+  const ref = useRef<HTMLDivElement>(null)
+  useForwardedRef(ref, forwardedRef)
+
+  return <div ref={ref} data-testid="container" />
+})
+
+describe('useForwardedRef', () => {
+  const render = createClientRender()
+
+  test('should copy forward ref as object to mutable ref', () => {
+    const ref = createRef<HTMLDivElement>()
+    render(<Fixture ref={ref} />)
+
+    expect(ref.current).toBe(screen.getByTestId('container'))
+  })
+
+  test('should copy forward ref as fn to mutable ref', () => {
+    const ref = createRef<HTMLDivElement | null>() as MutableRefObject<HTMLDivElement | null>
+    // eslint-disable-next-line react/jsx-no-bind
+    render(<Fixture ref={(node) => (ref.current = node)} />)
+
+    expect(ref.current).toBe(screen.getByTestId('container'))
+  })
+})

--- a/src/libs/forward-ref/useForwardedRef.ts
+++ b/src/libs/forward-ref/useForwardedRef.ts
@@ -1,0 +1,16 @@
+import { ForwardedRef, RefObject, useImperativeHandle } from 'react'
+
+/**
+ * Copies forwarded ref to mutable ref object.
+ *
+ * @example
+ * const Component = forwardRef<HTMLDivElement>((_, forwardedRef) => {
+ *   const ref = useRef<HTMLDivElement>(null)
+ *   useForwardedRef(ref, forwardedRef)
+ *
+ *   return <div ref={ref} />
+ * })
+ */
+export function useForwardedRef<T>(ref: RefObject<T>, forwardedRef: ForwardedRef<T>): void {
+  useImperativeHandle<T | null, T | null>(forwardedRef, () => ref.current)
+}


### PR DESCRIPTION
## Что сделал

Реализовал хук `useForwardedRef`, чтобы использовать его в сочетании с `forwardRef`, т.к. внутри хуков мы рассчитываем, что реф будет объектом, а `forwardRef` может принимать `callback`.

**Пример использования:**

```tsx
const Component = forwardRef<HTMLDivElement>((_, forwardedRef) => {
  const ref = useForwardedRef(forwardedRef)

  return <div ref={ref} />
})

(
  <>
    <Component ref={refObject} />
    <Component ref={(node) => refObject.current = node} />
  </>
)
```